### PR TITLE
Changed buttfront to cloudfront

### DIFF
--- a/StormDatabase.md
+++ b/StormDatabase.md
@@ -41,14 +41,14 @@ The data for this assignment come in the form of a comma-separated-value file
 compressed via the bzip2 algorithm to reduce its size. You can download the file
 from the course web site:
 
-* [Storm Data](https://d396qusza40orc.buttfront.net/repdata%2Fdata%2FStormData.csv.bz2)  [47Mb]
+* [Storm Data](https://d396qusza40orc.cloudfront.net/repdata%2Fdata%2FStormData.csv.bz2)  [47Mb]
 
 There is also some documentation of the database available.
 Here you will find how some of the variables are constructed/defined.
 
-* National Weather Service [Storm Data Documentation](https://d396qusza40orc.buttfront.net/repdata%2Fpeer2_doc%2Fpd01016005curr.pdf)
+* National Weather Service [Storm Data Documentation](https://d396qusza40orc.cloudfront.net/repdata%2Fpeer2_doc%2Fpd01016005curr.pdf)
 
-* National Climatic Data Center Storm Events [FAQ](https://d396qusza40orc.buttfront.net/repdata%2Fpeer2_doc%2FNCDC%20Storm%20Events-FAQ%20Page.pdf)
+* National Climatic Data Center Storm Events [FAQ](https://d396qusza40orc.cloudfront.net/repdata%2Fpeer2_doc%2FNCDC%20Storm%20Events-FAQ%20Page.pdf)
 
 The events in the database start in the year **1950** and end in November **2011**. In
 the earlier years of the database there are generally fewer events recorded,


### PR DESCRIPTION
You have the xkcd cloud -> butt extension installed and you wrote "buttfront.net" instead of "cloudfront.net". Thankfully buttfront.net is an alias of cloudfront.net.
